### PR TITLE
#5 feat: 초대장 뒷면 정보 입력

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -18,6 +18,7 @@ const StyledButton = styled.button<ButtonProps>`
   border-radius: 8px;
   padding: 1rem 0;
   font-size: 1rem;
+  font-weight: 500;
   cursor: pointer;
   transition: all 0.3s ease;
 

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -17,7 +17,6 @@ const StyledButton = styled.button<ButtonProps>`
   border: none;
   border-radius: 8px;
   padding: 1rem 0;
-  font-family: 'Pretendard';
   font-size: 1rem;
   cursor: pointer;
   transition: all 0.3s ease;

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -6,8 +6,9 @@ const StyledInput = styled.input<{
 }>`
   border: 1px solid #cfcdcd;
   border-radius: 8px;
-  width: ${(props) => props.width || '18.125rem'};
-  height: ${(props) => props.height || '2.3125rem'};
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
+  padding: 0 1.5rem;
 
   &:focus {
     outline: none;
@@ -21,12 +22,19 @@ const Input = ({
   value,
   onChange,
 }: {
-  width: string;
-  height: string;
+  width?: string;
+  height?: string;
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }) => {
-  return <StyledInput width={width} height={height} value={value} onChange={onChange} />;
+  return (
+    <StyledInput
+      width={width || '15.125rem'}
+      height={height || '2.3125rem'}
+      value={value}
+      onChange={onChange}
+    />
+  );
 };
 
 export default Input;

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+const StyledInput = styled.input<{
+  width: string;
+  height: string;
+}>`
+  border: 1px solid #cfcdcd;
+  border-radius: 8px;
+  width: ${(props) => props.width || '18.125rem'};
+  height: ${(props) => props.height || '2.3125rem'};
+`;
+
+const Input = ({ width, height }: { width: string; height: string }) => {
+  return <StyledInput width={width} height={height} />;
+};
+
+export default Input;

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -15,8 +15,18 @@ const StyledInput = styled.input<{
   }
 `;
 
-const Input = ({ width, height }: { width: string; height: string }) => {
-  return <StyledInput width={width} height={height} />;
+const Input = ({
+  width,
+  height,
+  value,
+  onChange,
+}: {
+  width: string;
+  height: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}) => {
+  return <StyledInput width={width} height={height} value={value} onChange={onChange} />;
 };
 
 export default Input;

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -8,6 +8,11 @@ const StyledInput = styled.input<{
   border-radius: 8px;
   width: ${(props) => props.width || '18.125rem'};
   height: ${(props) => props.height || '2.3125rem'};
+
+  &:focus {
+    outline: none;
+    box-shadow: none;
+  }
 `;
 
 const Input = ({ width, height }: { width: string; height: string }) => {

--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -16,8 +16,18 @@ const StyledTextArea = styled.textarea<{
   }
 `;
 
-const TextArea = ({ width, height }: { width: string; height: string }) => {
-  return <StyledTextArea width={width} height={height} />;
+const TextArea = ({
+  width,
+  height,
+  value,
+  onChange,
+}: {
+  width: string;
+  height: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+}) => {
+  return <StyledTextArea width={width} height={height} value={value} onChange={onChange} />;
 };
 
 export default TextArea;

--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+const StyledTextArea = styled.textarea<{
+  width: string;
+  height: string;
+}>`
+  border: 1px solid #cfcdcd;
+  border-radius: 8px;
+  resize: none;
+  width: ${(props) => props.width || '18.125rem'};
+  height: ${(props) => props.height || '7rem'};
+`;
+
+const TextArea = ({ width, height }: { width: string; height: string }) => {
+  return <StyledTextArea width={width} height={height} />;
+};
+
+export default TextArea;

--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -9,6 +9,11 @@ const StyledTextArea = styled.textarea<{
   resize: none;
   width: ${(props) => props.width || '18.125rem'};
   height: ${(props) => props.height || '7rem'};
+
+  &:focus {
+    outline: none;
+    box-shadow: none;
+  }
 `;
 
 const TextArea = ({ width, height }: { width: string; height: string }) => {

--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -7,8 +7,9 @@ const StyledTextArea = styled.textarea<{
   border: 1px solid #cfcdcd;
   border-radius: 8px;
   resize: none;
-  width: ${(props) => props.width || '18.125rem'};
-  height: ${(props) => props.height || '7rem'};
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
+  padding: 0.75rem 1.5rem;
 
   &:focus {
     outline: none;
@@ -22,12 +23,19 @@ const TextArea = ({
   value,
   onChange,
 }: {
-  width: string;
-  height: string;
+  width?: string;
+  height?: string;
   value: string;
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }) => {
-  return <StyledTextArea width={width} height={height} value={value} onChange={onChange} />;
+  return (
+    <StyledTextArea
+      width={width || '15.125rem'}
+      height={height || '7rem'}
+      value={value}
+      onChange={onChange}
+    />
+  );
 };
 
 export default TextArea;

--- a/src/components/result/InvitationBack.tsx
+++ b/src/components/result/InvitationBack.tsx
@@ -1,11 +1,40 @@
 import styled from 'styled-components';
 
+const InvitationBack = ({
+  title,
+  location,
+  message,
+}: {
+  title: string;
+  location: string;
+  message: string;
+}) => {
+  return (
+    <Container>
+      <Content>
+        <Title>{title}</Title>
+        <InfoFeild>
+          <b>일정</b>
+          <DateTime>2025. 03. 12 오후 5시</DateTime>
+        </InfoFeild>
+        <InfoFeild>
+          <b>장소</b>
+          <Location>{location}</Location>
+        </InfoFeild>
+        <Message>{message}</Message>
+      </Content>
+    </Container>
+  );
+};
+
+export default InvitationBack;
+
 const Container = styled.div`
   //TODO: width height props로 받도록 함
   width: 14.8125rem;
   height: 18.375rem;
   border-radius: 0.5rem;
-  // TODO: 템플릿 값을 참조하여 설정
+  // TODO: 템플릿 값을 참조하도록 설정
   background-color: #ff8383;
   color: #fff;
 `;
@@ -20,8 +49,8 @@ const Content = styled.div`
 
 const InfoFeild = styled.div`
   display: flex;
-  justify-content: center;
   gap: 0.25rem;
+  margin-left: 1.63rem;
 `;
 
 const DateTime = styled.div`
@@ -37,25 +66,7 @@ const Title = styled.div`
   font-size: 16px;
 `;
 
-const Style = styled.div``;
-
-const InvitationBack = () => {
-  return (
-    <Container>
-      <Content>
-        <Title>제목</Title>
-        <InfoFeild>
-          <b>일정</b>
-          <DateTime>2025. 03. 12 오후 5시</DateTime>
-        </InfoFeild>
-        <InfoFeild>
-          <b>장소</b>
-          <Location>영등포 12-3 000빌딩 4층 어쩌구저쩌구 길어지면?</Location>
-        </InfoFeild>
-        <Style>제발 아무것도 챙기지말고 몸만 와주길.</Style>
-      </Content>
-    </Container>
-  );
-};
-
-export default InvitationBack;
+const Message = styled.div`
+  display: flex;
+  margin-left: 1.63rem;
+`;

--- a/src/components/result/InvitationBack.tsx
+++ b/src/components/result/InvitationBack.tsx
@@ -15,14 +15,14 @@ const InvitationBack = ({
     <Container>
       <Content>
         <Title>{title}</Title>
-        <Feild>
+        <Field>
           <div>일정</div>
           <Info>{date}</Info>
-        </Feild>
-        <Feild>
+        </Field>
+        <Field>
           <div>장소</div>
           <Info>{location}</Info>
-        </Feild>
+        </Field>
         <Message>{message}</Message>
       </Content>
     </Container>
@@ -51,7 +51,7 @@ const Content = styled.div`
   font-size: 12px;
 `;
 
-const Feild = styled.div`
+const Field = styled.div`
   display: flex;
   align-items: center;
   gap: 0.25rem;

--- a/src/components/result/InvitationBack.tsx
+++ b/src/components/result/InvitationBack.tsx
@@ -4,12 +4,12 @@ const InvitationBack = ({
   title,
   date,
   location,
-  message,
+  description,
 }: {
   title: string;
   date: string;
   location: string;
-  message: string;
+  description: string;
 }) => {
   return (
     <Container>
@@ -23,7 +23,7 @@ const InvitationBack = ({
           <div>장소</div>
           <Info>{location}</Info>
         </Field>
-        <Message>{message}</Message>
+        <Description>{description}</Description>
       </Content>
     </Container>
   );
@@ -69,7 +69,7 @@ const Title = styled.div`
   font-size: 1rem;
 `;
 
-const Message = styled(Info)`
+const Description = styled(Info)`
   width: 12rem;
   white-space: pre-wrap;
   word-break: break-all;

--- a/src/components/result/InvitationBack.tsx
+++ b/src/components/result/InvitationBack.tsx
@@ -13,14 +13,14 @@ const InvitationBack = ({
     <Container>
       <Content>
         <Title>{title}</Title>
-        <InfoFeild>
-          <b>일정</b>
-          <DateTime>2025. 03. 12 오후 5시</DateTime>
-        </InfoFeild>
-        <InfoFeild>
-          <b>장소</b>
-          <Location>{location}</Location>
-        </InfoFeild>
+        <Feild>
+          <div>일정</div>
+          <Info>2025. 03. 12 오후 5시</Info>
+        </Feild>
+        <Feild>
+          <div>장소</div>
+          <Info>{location}</Info>
+        </Feild>
         <Message>{message}</Message>
       </Content>
     </Container>
@@ -37,6 +37,8 @@ const Container = styled.div`
   // TODO: 템플릿 값을 참조하도록 설정
   background-color: #ff8383;
   color: #fff;
+  font-weight: 500;
+  font-size: 0.625rem;
 `;
 
 const Content = styled.div`
@@ -47,26 +49,26 @@ const Content = styled.div`
   font-size: 12px;
 `;
 
-const InfoFeild = styled.div`
+const Feild = styled.div`
   display: flex;
+  align-items: center;
   gap: 0.25rem;
   margin-left: 1.63rem;
 `;
 
-const DateTime = styled.div`
+const Info = styled.div`
   max-width: 12rem;
-`;
-
-const Location = styled.div`
-  max-width: 12rem;
+  font-weight: 500;
+  font-size: 0.8125rem;
 `;
 
 const Title = styled.div`
   font-weight: 600;
-  font-size: 16px;
+  font-size: 1rem;
 `;
 
-const Message = styled.div`
-  display: flex;
-  margin-left: 1.63rem;
+const Message = styled(Info)`
+  width: 12rem;
+  word-break: break-all;
+  margin: 0 auto;
 `;

--- a/src/components/result/InvitationBack.tsx
+++ b/src/components/result/InvitationBack.tsx
@@ -2,10 +2,12 @@ import styled from 'styled-components';
 
 const InvitationBack = ({
   title,
+  date,
   location,
   message,
 }: {
   title: string;
+  date: string;
   location: string;
   message: string;
 }) => {
@@ -15,7 +17,7 @@ const InvitationBack = ({
         <Title>{title}</Title>
         <Feild>
           <div>일정</div>
-          <Info>2025. 03. 12 오후 5시</Info>
+          <Info>{date}</Info>
         </Feild>
         <Feild>
           <div>장소</div>

--- a/src/components/result/InvitationBack.tsx
+++ b/src/components/result/InvitationBack.tsx
@@ -71,6 +71,7 @@ const Title = styled.div`
 
 const Message = styled(Info)`
   width: 12rem;
+  white-space: pre-wrap;
   word-break: break-all;
   margin: 0 auto;
 `;

--- a/src/components/result/InvitationBack.tsx
+++ b/src/components/result/InvitationBack.tsx
@@ -1,16 +1,59 @@
 import styled from 'styled-components';
 
 const Container = styled.div`
-  width: 300px;
-  height: 500px;
-  background-color: #000;
+  //TODO: width height props로 받도록 함
+  width: 14.8125rem;
+  height: 18.375rem;
+  border-radius: 0.5rem;
+  // TODO: 템플릿 값을 참조하여 설정
+  background-color: #ff8383;
   color: #fff;
 `;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 2.87rem;
+  gap: 1.25rem;
+  font-size: 12px;
+`;
+
+const InfoFeild = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+`;
+
+const DateTime = styled.div`
+  max-width: 12rem;
+`;
+
+const Location = styled.div`
+  max-width: 12rem;
+`;
+
+const Title = styled.div`
+  font-weight: 600;
+  font-size: 16px;
+`;
+
+const Style = styled.div``;
 
 const InvitationBack = () => {
   return (
     <Container>
-      <h1>Back</h1>
+      <Content>
+        <Title>제목</Title>
+        <InfoFeild>
+          <b>일정</b>
+          <DateTime>2025. 03. 12 오후 5시</DateTime>
+        </InfoFeild>
+        <InfoFeild>
+          <b>장소</b>
+          <Location>영등포 12-3 000빌딩 4층 어쩌구저쩌구 길어지면?</Location>
+        </InfoFeild>
+        <Style>제발 아무것도 챙기지말고 몸만 와주길.</Style>
+      </Content>
     </Container>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -9,8 +9,19 @@ body {
   align-items: center;
   text-align: center;
   box-sizing: border-box;
-  font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Oxygen', 'Ubuntu', 'Cantarell',
-    'Fira Sans', 'Droid Sans', 'Pretendard', sans-serif;
+  font-family:
+    'Pretendard',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Oxygen',
+    'Ubuntu',
+    'Cantarell',
+    'Fira Sans',
+    'Droid Sans',
+    'Pretendard',
+    sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -20,6 +31,16 @@ input::placeholder,
 button,
 textarea,
 textarea::placeholder {
-  font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Oxygen', 'Ubuntu', 'Cantarell',
-    'Fira Sans', 'Droid Sans', 'Pretendard', sans-serif;
+  font-family:
+    'Pretendard',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Oxygen',
+    'Ubuntu',
+    'Cantarell',
+    'Fira Sans',
+    'Droid Sans',
+    sans-serif;
 }

--- a/src/pages/create/CreateBack.tsx
+++ b/src/pages/create/CreateBack.tsx
@@ -11,7 +11,7 @@ type DateField = 'year' | 'month' | 'day' | 'hour' | 'minute';
 const CreateBack = () => {
   const [title, setTitle] = useState('');
   const [location, setLocation] = useState('');
-  const [message, setMessage] = useState('');
+  const [description, setDescription] = useState('');
   const [date, setDate] = useState({
     year: '',
     month: '',
@@ -44,7 +44,7 @@ const CreateBack = () => {
         <InvitationBack
           title={title}
           location={location}
-          message={message}
+          description={description}
           date={`${date.year}년 ${date.month}월 ${date.day}일 ${date.hour}시 ${date.minute}분`}
         />
         <Gap>
@@ -74,10 +74,10 @@ const CreateBack = () => {
             <Input value={location} onChange={(e) => setLocation(e.target.value)} />
           </Field>
 
-          <MessageField>
+          <DescriptionField>
             <label>문구</label>
-            <TextArea value={message} onChange={(e) => setMessage(e.target.value)} />
-          </MessageField>
+            <TextArea value={description} onChange={(e) => setDescription(e.target.value)} />
+          </DescriptionField>
         </Gap>
       </AlignCenter>
     </Container>
@@ -135,7 +135,7 @@ const Field = styled.div`
   }
 `;
 
-const MessageField = styled(Field)`
+const DescriptionField = styled(Field)`
   align-items: flex-start;
   div {
     margin-top: 1.06rem;

--- a/src/pages/create/CreateBack.tsx
+++ b/src/pages/create/CreateBack.tsx
@@ -12,7 +12,7 @@ const CreateBack = () => {
   const [message, setMessage] = useState('');
 
   return (
-    <InputContainer>
+    <Container>
       {/* TODO: 헤더 */}
       <div>헤더</div>
       <b>
@@ -20,57 +20,53 @@ const CreateBack = () => {
       </b>
       <ButtonWrapper>
         <Button color={theme.color.main} textColor="#fff" fullWidth>
-          다음
+          초대장 생성하기
         </Button>
       </ButtonWrapper>
+
       <AlignCenter>
         <InvitationBack title={title} location={location} message={message} />
         <Gap>
-          <InputField>
-            <div>제목</div>
-            <Input
-              width={'18.125rem'}
-              height={'2.3125rem'}
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-            />
-          </InputField>
-          <InputField>
-            <div>일정</div>
+          <Field>
+            <label>제목</label>
+            <Input value={title} onChange={(e) => setTitle(e.target.value)} />
+          </Field>
+
+          <Field>
+            <label>일정</label>
             <DateInputWrapper>
               <DateInput />년 <DateInput />월 <DateInput />일 <DateInput />시 <DateInput />분
             </DateInputWrapper>
-          </InputField>
-          <InputField>
-            <div>장소</div>
-            <Input
-              width={'18.125rem'}
-              height={'2.3125rem'}
-              value={location}
-              onChange={(e) => setLocation(e.target.value)}
-            />
-          </InputField>
-          <InputField>
-            <div>문구</div>
-            <TextArea
-              width={'18.125rem'}
-              height={'7rem'}
-              value={message}
-              onChange={(e) => setMessage(e.target.value)}
-            />
-          </InputField>
+          </Field>
+
+          <Field>
+            <label>장소</label>
+            <Input value={location} onChange={(e) => setLocation(e.target.value)} />
+          </Field>
+
+          <MessageField>
+            <label>문구</label>
+            <TextArea value={message} onChange={(e) => setMessage(e.target.value)} />
+          </MessageField>
         </Gap>
       </AlignCenter>
-    </InputContainer>
+    </Container>
   );
 };
 
 export default CreateBack;
 
-const InputContainer = styled.div`
+const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2.25rem;
+  margin-bottom: 6.12rem;
+  font-weight: 500;
+
+  input,
+  textarea {
+    font-weight: 500;
+  }
 
   b {
     text-align: left;
@@ -86,7 +82,7 @@ const ButtonWrapper = styled.div`
   width: 21.375rem;
 `;
 
-const AlignCenter = styled(InputContainer)`
+const AlignCenter = styled(Container)`
   align-items: center;
   gap: 1.81rem;
   z-index: 0;
@@ -98,9 +94,22 @@ const Gap = styled.div`
   gap: 1.06rem;
 `;
 
-const InputField = styled.div`
+const Field = styled.div`
   display: flex;
   gap: 1.69rem;
+  align-items: center;
+  font-size: 0.875rem;
+
+  label {
+    color: #3e3e3e;
+  }
+`;
+
+const MessageField = styled(Field)`
+  align-items: flex-start;
+  div {
+    margin-top: 1.06rem;
+  }
 `;
 
 const DateInput = styled.input`
@@ -120,8 +129,8 @@ const DateInputWrapper = styled.div`
   justify-content: center;
   border: 1px solid #cfcdcd;
   border-radius: 8px;
-  width: 18.125rem;
+  width: 15.125rem;
   height: 2.3125rem;
-  padding: 1px 2px;
-  gap: 0.2rem;
+  padding: 1px 1.5rem;
+  font-size: 0.875rem;
 `;

--- a/src/pages/create/CreateBack.tsx
+++ b/src/pages/create/CreateBack.tsx
@@ -1,5 +1,48 @@
+import styled from 'styled-components';
+import Input from '../../components/common/Input';
+import TextArea from '../../components/common/TextArea';
+
+const InputContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.06rem;
+`;
+
+const InputField = styled.div`
+  display: flex;
+  gap: 1.69rem;
+`;
+
 const CreateBack = () => {
-  return <div>CreateBack</div>;
+  return (
+    <>
+      {/* TODO: 헤더 */}
+      <div>헤더</div>
+      <div>뒷면카드</div>
+      <p style={{ textAlign: 'left' }}>
+        초대장 뒷면에 들어갈 <br /> 상세정보를 입력해주세요!
+      </p>
+
+      <InputContainer>
+        <InputField>
+          <div>제목</div>
+          <Input width={'18.125rem'} height={'2.3125rem'} />
+        </InputField>
+        <InputField>
+          <div>일정</div>
+          <Input width={'18.125rem'} height={'2.3125rem'} />
+        </InputField>
+        <InputField>
+          <div>장소</div>
+          <Input width={'18.125rem'} height={'2.3125rem'} />
+        </InputField>
+        <InputField>
+          <div>문구</div>
+          <TextArea width={'18.125rem'} height={'7rem'} />
+        </InputField>
+      </InputContainer>
+    </>
+  );
 };
 
 export default CreateBack;

--- a/src/pages/create/CreateBack.tsx
+++ b/src/pages/create/CreateBack.tsx
@@ -6,6 +6,8 @@ import InvitationBack from '../../components/result/InvitationBack';
 import Button from '../../components/common/Button';
 import theme from '../../style/theme';
 
+type DateField = 'year' | 'month' | 'day' | 'hour' | 'minute';
+
 const CreateBack = () => {
   const [title, setTitle] = useState('');
   const [location, setLocation] = useState('');
@@ -18,7 +20,7 @@ const CreateBack = () => {
     minute: '',
   });
 
-  const handleDateChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleDateChange = (field: DateField) => (e: React.ChangeEvent<HTMLInputElement>) => {
     setDate((prev) => ({
       ...prev,
       [field]: e.target.value,

--- a/src/pages/create/CreateBack.tsx
+++ b/src/pages/create/CreateBack.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 import Input from '../../components/common/Input';
 import TextArea from '../../components/common/TextArea';
 import InvitationBack from '../../components/result/InvitationBack';
+import Button from '../../components/common/Button';
+import theme from '../../style/theme';
 
 const CreateBack = () => {
   const [title, setTitle] = useState('');
@@ -16,6 +18,11 @@ const CreateBack = () => {
       <b>
         초대장 뒷면에 들어갈 <br /> 상세정보를 입력해주세요!
       </b>
+      <ButtonWrapper>
+        <Button color={theme.color.main} textColor="#fff" fullWidth>
+          다음
+        </Button>
+      </ButtonWrapper>
       <AlignCenter>
         <InvitationBack title={title} location={location} message={message} />
         <Gap>
@@ -70,9 +77,19 @@ const InputContainer = styled.div`
   }
 `;
 
+const ButtonWrapper = styled.div`
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  width: 21.375rem;
+`;
+
 const AlignCenter = styled(InputContainer)`
   align-items: center;
   gap: 1.81rem;
+  z-index: 0;
 `;
 
 const Gap = styled.div`

--- a/src/pages/create/CreateBack.tsx
+++ b/src/pages/create/CreateBack.tsx
@@ -1,7 +1,64 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 import Input from '../../components/common/Input';
 import TextArea from '../../components/common/TextArea';
 import InvitationBack from '../../components/result/InvitationBack';
+
+const CreateBack = () => {
+  const [title, setTitle] = useState('');
+  const [location, setLocation] = useState('');
+  const [message, setMessage] = useState('');
+
+  return (
+    <InputContainer>
+      {/* TODO: 헤더 */}
+      <div>헤더</div>
+      <b>
+        초대장 뒷면에 들어갈 <br /> 상세정보를 입력해주세요!
+      </b>
+      <AlignCenter>
+        <InvitationBack title={title} location={location} message={message} />
+        <Gap>
+          <InputField>
+            <div>제목</div>
+            <Input
+              width={'18.125rem'}
+              height={'2.3125rem'}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </InputField>
+          <InputField>
+            <div>일정</div>
+            <DateInputWrapper>
+              <DateInput />년 <DateInput />월 <DateInput />일 <DateInput />시 <DateInput />분
+            </DateInputWrapper>
+          </InputField>
+          <InputField>
+            <div>장소</div>
+            <Input
+              width={'18.125rem'}
+              height={'2.3125rem'}
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+            />
+          </InputField>
+          <InputField>
+            <div>문구</div>
+            <TextArea
+              width={'18.125rem'}
+              height={'7rem'}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+            />
+          </InputField>
+        </Gap>
+      </AlignCenter>
+    </InputContainer>
+  );
+};
+
+export default CreateBack;
 
 const InputContainer = styled.div`
   display: flex;
@@ -29,37 +86,25 @@ const InputField = styled.div`
   gap: 1.69rem;
 `;
 
-const CreateBack = () => {
-  return (
-    <InputContainer>
-      {/* TODO: 헤더 */}
-      <div>헤더</div>
-      <b>
-        초대장 뒷면에 들어갈 <br /> 상세정보를 입력해주세요!
-      </b>
-      <AlignCenter>
-        <InvitationBack />
-        <Gap>
-          <InputField>
-            <div>제목</div>
-            <Input width={'18.125rem'} height={'2.3125rem'} />
-          </InputField>
-          <InputField>
-            <div>일정</div>
-            <Input width={'18.125rem'} height={'2.3125rem'} />
-          </InputField>
-          <InputField>
-            <div>장소</div>
-            <Input width={'18.125rem'} height={'2.3125rem'} />
-          </InputField>
-          <InputField>
-            <div>문구</div>
-            <TextArea width={'18.125rem'} height={'7rem'} />
-          </InputField>
-        </Gap>
-      </AlignCenter>
-    </InputContainer>
-  );
-};
+const DateInput = styled.input`
+  width: 2rem;
+  border: none;
+  text-align: right;
 
-export default CreateBack;
+  &:focus {
+    outline: none;
+    box-shadow: none;
+  }
+`;
+
+const DateInputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #cfcdcd;
+  border-radius: 8px;
+  width: 18.125rem;
+  height: 2.3125rem;
+  padding: 1px 2px;
+  gap: 0.2rem;
+`;

--- a/src/pages/create/CreateBack.tsx
+++ b/src/pages/create/CreateBack.tsx
@@ -1,8 +1,24 @@
 import styled from 'styled-components';
 import Input from '../../components/common/Input';
 import TextArea from '../../components/common/TextArea';
+import InvitationBack from '../../components/result/InvitationBack';
 
 const InputContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2.25rem;
+
+  b {
+    text-align: left;
+  }
+`;
+
+const AlignCenter = styled(InputContainer)`
+  align-items: center;
+  gap: 1.81rem;
+`;
+
+const Gap = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.06rem;
@@ -15,33 +31,34 @@ const InputField = styled.div`
 
 const CreateBack = () => {
   return (
-    <>
+    <InputContainer>
       {/* TODO: 헤더 */}
       <div>헤더</div>
-      <div>뒷면카드</div>
-      <p style={{ textAlign: 'left' }}>
+      <b>
         초대장 뒷면에 들어갈 <br /> 상세정보를 입력해주세요!
-      </p>
-
-      <InputContainer>
-        <InputField>
-          <div>제목</div>
-          <Input width={'18.125rem'} height={'2.3125rem'} />
-        </InputField>
-        <InputField>
-          <div>일정</div>
-          <Input width={'18.125rem'} height={'2.3125rem'} />
-        </InputField>
-        <InputField>
-          <div>장소</div>
-          <Input width={'18.125rem'} height={'2.3125rem'} />
-        </InputField>
-        <InputField>
-          <div>문구</div>
-          <TextArea width={'18.125rem'} height={'7rem'} />
-        </InputField>
-      </InputContainer>
-    </>
+      </b>
+      <AlignCenter>
+        <InvitationBack />
+        <Gap>
+          <InputField>
+            <div>제목</div>
+            <Input width={'18.125rem'} height={'2.3125rem'} />
+          </InputField>
+          <InputField>
+            <div>일정</div>
+            <Input width={'18.125rem'} height={'2.3125rem'} />
+          </InputField>
+          <InputField>
+            <div>장소</div>
+            <Input width={'18.125rem'} height={'2.3125rem'} />
+          </InputField>
+          <InputField>
+            <div>문구</div>
+            <TextArea width={'18.125rem'} height={'7rem'} />
+          </InputField>
+        </Gap>
+      </AlignCenter>
+    </InputContainer>
   );
 };
 

--- a/src/pages/create/CreateBack.tsx
+++ b/src/pages/create/CreateBack.tsx
@@ -10,6 +10,20 @@ const CreateBack = () => {
   const [title, setTitle] = useState('');
   const [location, setLocation] = useState('');
   const [message, setMessage] = useState('');
+  const [date, setDate] = useState({
+    year: '',
+    month: '',
+    day: '',
+    hour: '',
+    minute: '',
+  });
+
+  const handleDateChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setDate((prev) => ({
+      ...prev,
+      [field]: e.target.value,
+    }));
+  };
 
   return (
     <Container>
@@ -25,7 +39,12 @@ const CreateBack = () => {
       </ButtonWrapper>
 
       <AlignCenter>
-        <InvitationBack title={title} location={location} message={message} />
+        <InvitationBack
+          title={title}
+          location={location}
+          message={message}
+          date={`${date.year}년 ${date.month}월 ${date.day}일 ${date.hour}시 ${date.minute}분`}
+        />
         <Gap>
           <Field>
             <label>제목</label>
@@ -35,7 +54,16 @@ const CreateBack = () => {
           <Field>
             <label>일정</label>
             <DateInputWrapper>
-              <DateInput />년 <DateInput />월 <DateInput />일 <DateInput />시 <DateInput />분
+              <DateInput type="number" value={date.year} onChange={handleDateChange('year')} /> 년
+              <DateInput type="number" value={date.month} onChange={handleDateChange('month')} /> 월
+              <DateInput type="number" value={date.day} onChange={handleDateChange('day')} /> 일
+              <DateInput type="number" value={date.hour} onChange={handleDateChange('hour')} /> 시
+              <DateInput
+                type="number"
+                value={date.minute}
+                onChange={handleDateChange('minute')}
+              />{' '}
+              분
             </DateInputWrapper>
           </Field>
 

--- a/src/pages/create/InvitationCreate.tsx
+++ b/src/pages/create/InvitationCreate.tsx
@@ -1,5 +1,7 @@
+import CreateBack from './CreateBack';
+
 const InvitationCreate = () => {
-  return <div>{/* TODO: step에 따른 컴포넌트 렌더링*/}</div>;
+  return <CreateBack />;
 };
 
 export default InvitationCreate;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
#5 를 구현했습니다
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- 주소 입력은 기획적인 부분에서 조금 더 얘기해봐야할 것 같아서 우선은 똑같이 input으로 구현해두었습니당 (노션이나 슬랙에 정리해두겠습니다,,)
- 값이 입력되지 않았을 경우에 어떻게 보여질지도 디자이너분과 더 얘기해봐야할 것 같아서 우선은 입력값의 존재 유무에 따른 스타일링을 지정하지 않았습니다! 얘기해보고 공유해드릴게요 ..
- 헤더는 만들고 나면 추가하려고 비워두었습니당

<br>

## 3. 관련 스크린샷을 첨부해주세요.

값 입력 전
<img width="418" alt="스크린샷 2025-01-08 오전 12 23 55" src="https://github.com/user-attachments/assets/f1f7e947-7aca-4306-989a-1869ca8c8700" />
값 입력 후
<img width="411" alt="스크린샷 2025-01-08 오전 12 26 54" src="https://github.com/user-attachments/assets/6e6701a8-ba08-44c2-9930-915a5d9f5fd9" />

버튼 위치 고정

https://github.com/user-attachments/assets/5e818181-5a24-4870-b3dd-bc95f27335b8



<br>

## 4. 완료 사항
- 초대장 뒷면 정보 입력 UI 구현
- 입력한 값을 저장
- 입력한 값으로 미리보기 생성
- 공통 컴포넌트 Input, TextArea를 만들었습니다! width, height값을 전달하지 않을 시 초대장 뒷면 입력 페이지 사이즈가 적용됩니당

<br>

## 5. 추가 사항
