### PR TITLE
#16 feat 초대장 데이터 폰트 크기+컬러 속성 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@lottiefiles/dotlottie-react": "^0.12.1",
     "axios": "^1.7.9",
     "clipboard": "^2.0.11",
     "react": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { RecoilRoot } from 'recoil';
 import InvitationList from './pages/mypage/InvitationList';
 import MyPageMain from './pages/mypage/MyPageMain';
 import InvitationDetail from './pages/mypage/InvitationDetail';
+import ErrorPage from './pages/ErrorPage';
 
 function App() {
   return (
@@ -27,6 +28,7 @@ function App() {
             <Route path="send" element={<InvitationList type="send" />} />
             <Route path="detail/:id" element={<InvitationDetail />} />
           </Route>
+          <Route path="*" element={<ErrorPage />} />
         </Routes>
       </BrowserRouter>
     </RecoilRoot>

--- a/src/components/create/TemplateFront.tsx
+++ b/src/components/create/TemplateFront.tsx
@@ -91,6 +91,7 @@ const TemplateFrontContainer = styled.div<{ src: string }>`
   width: 321px;
   height: 401px;
   border-radius: 8px;
+  box-shadow: 0px 4px 6px 0px rgba(0, 0, 0, 0.25);
 `;
 
 const InvitationText = styled.div<{ top: number; left: number }>`

--- a/src/components/create/TemplateFront.tsx
+++ b/src/components/create/TemplateFront.tsx
@@ -2,7 +2,8 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import TextArea from '../../components/common/TextArea';
 import { template } from '../../data/Template';
-import { InvitationState } from '../../atom/InvitationInfo';
+import { InvitationInfo, InvitationState } from '../../atom/InvitationInfo';
+import { useRecoilValue } from 'recoil';
 
 interface TemplateFrontProps {
   templateKey: keyof typeof template;
@@ -15,6 +16,7 @@ const TemplateFront: React.FC<TemplateFrontProps> = ({
   invitation,
   setInvitation,
 }) => {
+  const { step } = useRecoilValue(InvitationInfo);
   // 텍스트 초기화 함수
   const initializeTextValues = () => {
     return new Array(template[templateKey].text_cnt).fill('');
@@ -60,10 +62,10 @@ const TemplateFront: React.FC<TemplateFrontProps> = ({
 
   return (
     <TemplateFrontContainer src={template[templateKey].template_src}>
-      {template[templateKey].text_position_size.map((el, index) => {
-        const length = calculateMaxLength(el[2], el[3], 11);
+      {template[templateKey].text_attr.map((el, index) => {
+        const length = calculateMaxLength(el[2] as number, el[3] as number, el[4] as number);
         return (
-          <InvitationText key={index} top={el[0]} left={el[1]}>
+          <InvitationText key={index} top={el[0] as number} left={el[1] as number}>
             <InvitationTextArea
               width={`${el[2]}px`}
               height={`${el[3]}px`}
@@ -73,6 +75,9 @@ const TemplateFront: React.FC<TemplateFrontProps> = ({
               }
               maxLength={length}
               font={template[templateKey].font}
+              fontSize={el[4] as number}
+              fontColor={el[5] as string}
+              step={step}
             />
           </InvitationText>
         );
@@ -100,13 +105,22 @@ const InvitationText = styled.div<{ top: number; left: number }>`
   left: ${(props) => `${props.left}px`};
 `;
 
-const InvitationTextArea = styled(TextArea)<{ font: string }>`
+const InvitationTextArea = styled(TextArea)<{
+  font: string;
+  fontSize: number;
+  fontColor: string;
+  step: number;
+}>`
   overflow: hidden;
+  background-color: inherit;
   padding: 0.2rem 0.25rem;
   box-sizing: border-box;
   text-align: center;
   font-size: 11px;
   border-radius: 4px;
-  border: 1px solid #787878;
+  // 2단계 경우에만, textarea border 존재재
+  border: ${(props) => (props.step == 2 ? '1px solid #787878' : 'none')};
   font-family: ${(props) => props.font};
+  font-size: ${(props) => `${props.fontSize}px`};
+  color: ${(props) => props.fontColor};
 `;

--- a/src/components/create/TemplatePreview.tsx
+++ b/src/components/create/TemplatePreview.tsx
@@ -95,6 +95,7 @@ const PreviewFront = styled.img`
   width: 166px;
   height: 207px;
   border-radius: 8px;
+  box-shadow: 0px 4px 6px 0px rgba(0, 0, 0, 0.25);
 `;
 
 const PreviewBack = styled.div<{ isTemplate: boolean; bgColor: string }>`
@@ -103,6 +104,7 @@ const PreviewBack = styled.div<{ isTemplate: boolean; bgColor: string }>`
   border-radius: 8px;
   border: ${(props) => (props.isTemplate ? 'none' : '1px solid #cfcdcd')};
   background-color: ${(props) => props.bgColor};
+  box-shadow: 0px 4px 6px 0px rgba(0, 0, 0, 0.25);
 `;
 
 const SelectContainer = styled.div`
@@ -141,4 +143,5 @@ const ImageItem = styled.img`
   height: 100%;
   border-radius: 8px;
   object-fit: cover;
+  border: 1px solid #cfcdcd;
 `;

--- a/src/components/layout/HomeHeader.tsx
+++ b/src/components/layout/HomeHeader.tsx
@@ -3,15 +3,11 @@ import { TbUserCircle } from 'react-icons/tb';
 import { Link } from 'react-router-dom';
 
 export const HomeHeader = () => {
-  const currentUrl = window.location.href.split('/').reverse()[0];
-
   return (
     <Section>
-      {currentUrl === 'home' && (
-        <MyPageLink to="/mypage">
-          <TbUserCircle strokeWidth={1} color="#3E3E3E" />
-        </MyPageLink>
-      )}
+      <MyPageLink to="/mypage">
+        <TbUserCircle strokeWidth={1} color="#3E3E3E" />
+      </MyPageLink>
     </Section>
   );
 };

--- a/src/components/layout/MyPageHeader.tsx
+++ b/src/components/layout/MyPageHeader.tsx
@@ -9,9 +9,11 @@ export const MyPageHeader = () => {
 
   const handleClose = () => {
     if (location.pathname.startsWith('/mypage/detail/')) {
-      navigate(-1);
+      navigate(-1); // /mypage/send /received구분해서 보내고 싶긴한데...
     } else if (location.pathname === '/mypage') {
       navigate('/home');
+    } else if (location.pathname.startsWith('/result/')) {
+      navigate('/home', { replace: true });
     }
   };
 

--- a/src/components/layout/MyPageHeader.tsx
+++ b/src/components/layout/MyPageHeader.tsx
@@ -9,14 +9,15 @@ export const MyPageHeader = () => {
 
   const handleClose = () => {
     if (location.pathname.startsWith('/mypage/detail/')) {
-      navigate(-1); // /mypage/send /received구분해서 보내고 싶긴한데...
+      navigate(-1);
+    } else if (location.pathname.startsWith('/mypage/')) {
+      navigate('/mypage');
     } else if (location.pathname === '/mypage') {
       navigate('/home');
     } else if (location.pathname.startsWith('/result/')) {
       navigate('/home', { replace: true });
     }
   };
-
   return (
     <Section>
       <LeftButton

--- a/src/components/layout/MyPageHeader.tsx
+++ b/src/components/layout/MyPageHeader.tsx
@@ -54,6 +54,9 @@ const Section = styled.section`
   justify-content: space-between;
   padding: 1rem 0;
   width: 100%;
+  max-width: 480px;
+  z-index: 1;
+  background-color: white;
 `;
 
 const LeftButton = styled(FiChevronLeft)`

--- a/src/data/Template.ts
+++ b/src/data/Template.ts
@@ -4,12 +4,12 @@ export const template = {
     template_pre_src: '/image/Pre_Invi_Alien.png', // 2. 템플릿 미리보기 이미지 파일 (텍스트 O)
     font: 'BMHANNAPro',
     text_cnt: 4, // 3. 포함되는 텍스트창 개수
-    text_position_size: [
-      [78, 83, 167, 25],
-      [222, 54, 91, 20],
-      [286, 54, 91, 20],
-      [326, 48, 103, 35],
-    ], // 4. 각 텍스트창 속성 (top,left,width,height)
+    text_attr: [
+      [78, 83, 167, 25, 18, '#3E3E3E'],
+      [222, 54, 91, 20, 14, '#3E3E3E'],
+      [286, 54, 91, 20, 14, '#3E3E3E'],
+      [326, 48, 103, 35, 14, '#3E3E3E'],
+    ], // 4. 각 텍스트창 속성 (top,left,width,height,font-size,font-color)
     bg_color: '#04FD0B', // 5. 초대장 뒷면 배경 컬러
     bg_text_color: '#FFFFFF', // 6. 초대장 뒷면 텍스트 컬러
   },
@@ -18,12 +18,12 @@ export const template = {
     template_pre_src: '/image/Pre_Invi_Rabbit.png',
     font: 'CookieRun-Regular',
     text_cnt: 5,
-    text_position_size: [
-      [83, 98, 111, 34],
-      [135, 55, 210, 63],
-      [207, 138, 91, 20],
-      [207, 138, 91, 20],
-      [312, 68, 92, 34],
+    text_attr: [
+      [83, 98, 111, 34, 24, '#3E3E3E'],
+      [135, 55, 210, 63, 13, '#3E3E3E'],
+      [207, 138, 91, 20, 13, '#3E3E3E'],
+      [207, 138, 91, 20, 13, '#3E3E3E'],
+      [312, 68, 92, 34, 14, '#3E3E3E'],
     ],
     bg_color: '#FF6666',
     bg_text_color: '#FFFFFF',
@@ -33,11 +33,11 @@ export const template = {
     template_pre_src: '/image/Pre_Invi_Cyber.png',
     font: 'DOSIyagiMedium',
     text_cnt: 4,
-    text_position_size: [
-      [109, 81, 166, 28],
-      [148, 101, 121, 20],
-      [171, 101, 121, 20],
-      [206, 60, 210, 63],
+    text_attr: [
+      [109, 81, 166, 28, 20, '#000000'],
+      [148, 101, 121, 20, 14, '#000000'],
+      [171, 101, 121, 20, 14, '#000000'],
+      [206, 60, 210, 63, 14, '#000000'],
     ],
     bg_color: '#80EDFF',
     bg_text_color: '#FFFFFF',
@@ -47,10 +47,10 @@ export const template = {
     template_pre_src: '/image/Pre_Invi_Chirashi.png',
     font: 'Pretendard-Regular',
     text_cnt: 3,
-    text_position_size: [
-      [43, 82, 221, 59],
-      [179, 43, 235, 122],
-      [323, 45, 228, 33],
+    text_attr: [
+      [43, 82, 221, 59, 30, '#3E3E3E'],
+      [179, 43, 235, 122, 20, '#F4F7FF'],
+      [323, 45, 228, 33, 24, '#FFFF3B'],
     ],
     bg_color: '#3E68FF',
     bg_text_color: '#FFFFFF',
@@ -60,7 +60,7 @@ export const template = {
     template_pre_src: '/image/Pre_Invi_Princess.png',
     font: 'Ownglyph_ParkDaHyun',
     text_cnt: 1,
-    text_position_size: [[203, 43, 235, 65]],
+    text_attr: [[203, 43, 235, 65, 20, '#3E3E3E']],
     bg_color: '#FF5596',
     bg_text_color: '#FFFFFF',
   },
@@ -69,11 +69,11 @@ export const template = {
     template_pre_src: '/image/Pre_Invi_Receipt.png',
     font: 'Pretendard',
     text_cnt: 4,
-    text_position_size: [
-      [151, 98, 124, 25],
-      [259, 121, 129, 20],
-      [286, 121, 129, 20],
-      [313, 121, 129, 20],
+    text_attr: [
+      [151, 98, 124, 25, 18, '#3E3E3E'],
+      [259, 121, 129, 20, 12, '#3E3E3E'],
+      [286, 121, 129, 20, 12, '#3E3E3E'],
+      [313, 121, 129, 20, 12, '#3E3E3E'],
     ],
     bg_color: '#FF8383',
     bg_text_color: '#FFFFFF',

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,0 +1,54 @@
+import styled from 'styled-components';
+import Button from '../components/common/Button';
+import { BiSolidMessageError } from 'react-icons/bi';
+import { getCookie } from '../utils/cookies';
+import { useNavigate } from 'react-router-dom';
+import theme from '../style/theme';
+
+const ErrorPage = () => {
+  const navigate = useNavigate();
+  const handleBackStep = () => {
+    const accessToken = getCookie('accessToken');
+    if (accessToken == undefined) {
+      // 토큰이 존재하지 않은 경우
+      navigate('/', { replace: true });
+    } else {
+      // 토큰이 존재하는 경우
+      navigate('/home', { replace: true });
+    }
+  };
+
+  return (
+    <Container>
+      <BiSolidMessageError color={theme.color.main} size={30} />
+      <Phrase>존재하지 않는 페이지입니다.</Phrase>
+      <Button
+        onClick={handleBackStep}
+        color="white"
+        textColor="#3E3E3E"
+        border="1.5px solid #C2C2C2"
+        size="medium"
+      >
+        돌아가기
+      </Button>
+    </Container>
+  );
+};
+
+export default ErrorPage;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+  width: 100%;
+  max-width: 480px;
+  height: 100vh;
+`;
+
+const Phrase = styled.div`
+  font-size: 1.5rem;
+  font-weight: 500;
+`;

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -20,7 +20,7 @@ const ErrorPage = () => {
 
   return (
     <Container>
-      <BiSolidMessageError color={theme.color.main} size={30} />
+      <BiSolidMessageError color={theme.color.main} size={56} />
       <Phrase>존재하지 않는 페이지입니다.</Phrase>
       <Button
         onClick={handleBackStep}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -11,7 +11,6 @@ export const Home = () => {
   const handleMakeInvitation = () => {
     navigate('/invitation/create');
   };
-
   return (
     <Container>
       <HomeHeader />

--- a/src/pages/create/CreateNickname.tsx
+++ b/src/pages/create/CreateNickname.tsx
@@ -1,23 +1,35 @@
 import styled from 'styled-components';
+import { useState } from 'react';
 import { InvitationHeader } from '../../components/layout/InvitationHeader';
 import Button from '../../components/common/Button';
 import theme from '../../style/theme';
 import Input from '../../components/common/Input';
+import { IoAlertCircleOutline } from 'react-icons/io5';
 import { useRecoilState } from 'recoil';
 import { InvitationInfo, InvitationState } from '../../atom/InvitationInfo';
 import { useResetStepState } from '../../hooks/useResetStepState';
 
 const CreateNickName = () => {
   const [invitation, setInvitation] = useRecoilState<InvitationState>(InvitationInfo);
+  const [isNotNull, setIsNotNull] = useState(-1); // -1 : 초기상태 , 0 : 유효성 검증 실패, 1 : 유효성 검증 성공
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const nickname = e.target.value;
     setInvitation((prev) => ({ ...prev, nickname: nickname }));
+
+    // 경고 문구 초기화
+    if (nickname !== '') setIsNotNull(1);
+    else setIsNotNull(0);
   };
 
   // 다음단계
   const handleNextButtonClick = () => {
-    setInvitation((prev) => ({ ...prev, step: 1 }));
+    if (invitation.nickname === '') {
+      setIsNotNull(0);
+    } else {
+      setIsNotNull(1);
+      setInvitation((prev) => ({ ...prev, step: 1 }));
+    }
   };
 
   useResetStepState();
@@ -38,6 +50,12 @@ const CreateNickName = () => {
               placeholder="10자 내로 작성해주세요."
               maxLength={10}
             />
+            {isNotNull == 0 && (
+              <ErrorPhrase>
+                <IoAlertCircleOutline size={13} />
+                <span>닉네임을 입력해주세요</span>
+              </ErrorPhrase>
+            )}
           </InputField>
         </NicknameForm>
       </MainContent>
@@ -110,8 +128,20 @@ const InputField = styled.div`
 
 const NicknameInput = styled(Input)`
   width: 100%;
+  margin: 0.5rem 0 0.813rem 0;
   padding: 0 1rem;
   box-sizing: border-box;
+`;
+
+const ErrorPhrase = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.313rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  > * {
+    color: #ff8b8b;
+  }
 `;
 
 const NextButton = styled(Button)`

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,8 +1,7 @@
 import styled from 'styled-components';
-import LOGO from '/image/yes.svg'; // 로고 SVG 파일을 import
 import Button from '../../components/common/Button';
-import { HomeHeader } from '../../components/layout/HomeHeader';
 import theme from '../../style/theme';
+import { DotLottieReact } from '@lottiefiles/dotlottie-react';
 
 export const Login = () => {
   // oauth 요청 URL
@@ -14,8 +13,12 @@ export const Login = () => {
 
   return (
     <Container>
-      <HomeHeader />
-      <Logo src={LOGO} />
+      <LottieWrapper>
+        <DotLottieReact
+          src="https://lottie.host/86ced484-225b-440b-83cf-d99e3f1056c0/IejUx6FXJ1.lottie"
+          autoplay
+        />
+      </LottieWrapper>
       <KakaoLoginButton color={theme.color.kakao} onClick={handleLogin}>
         카카오로 로그인하기
       </KakaoLoginButton>
@@ -24,23 +27,30 @@ export const Login = () => {
 };
 
 const Container = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   height: 100vh;
   width: 100vw;
   max-width: 480px;
-  overflow-y: hidden;
+  overflow: hidden;
 `;
 
-const Logo = styled.img`
+const LottieWrapper = styled.div`
+  position: absolute;
   width: 100%;
-  max-width: 211px;
-  height: auto;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  bottom: -5rem;
 `;
 
 const KakaoLoginButton = styled(Button)`
+  position: absolute;
+  bottom: 2.625rem;
   width: 90%;
-  margin-bottom: 2.625rem;
+  z-index: 1;
 `;

--- a/src/pages/mypage/InvitationDetail.tsx
+++ b/src/pages/mypage/InvitationDetail.tsx
@@ -77,6 +77,8 @@ const Invitation = styled.div<{ isTouched: boolean }>`
   transform-style: preserve-3d;
   transition: transform 0.8s ease;
   transform: ${({ isTouched }) => (isTouched ? 'rotateY(180deg)' : 'rotateY(0deg)')};
+  border-radius: 8px;
+  box-shadow: 0px 4px 6px 0px rgba(0, 0, 0, 0.25);
 `;
 
 const DefaultInvitationStyle = styled.div`

--- a/src/pages/mypage/InvitationList.tsx
+++ b/src/pages/mypage/InvitationList.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import InvitationOverview from '../../components/mypage/InvitationOverview';
 import styled from 'styled-components';
-import { FiChevronRight } from 'react-icons/fi';
 
 // 예시 데이터
 const data = [
@@ -78,7 +77,6 @@ const InvitationList = ({ type }: { type: string }) => {
     <Container key={index}>
       <Header>
         <div className="made-date">{date}</div>
-        <FiChevronRight strokeWidth={2} size={24} />
       </Header>
       {groupedInvitations[date].map((invitation: Invitation) => (
         <InvitationOverview key={invitation.id} invitation={invitation} />
@@ -101,10 +99,10 @@ const Container = styled.div`
 
 const Header = styled.div`
   display: flex;
-  justify-content: space-between;
   align-items: center;
 
   .made-date {
+    margin-right: auto;
     color: #3e3e3e;
     font-weight: 600;
     font-size: 20px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -420,6 +420,18 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@lottiefiles/dotlottie-react@^0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@lottiefiles/dotlottie-react/-/dotlottie-react-0.12.1.tgz#b71949f28d3cf1fda73814b4b068e835a30082b9"
+  integrity sha512-8l0db31gqozQMC2ZfzV6NWN1cit/NOlevVgS98qC2N4vugS6CZ6IWE4EfLLJEa9DILSinENDE4K85+eIJw4MOQ==
+  dependencies:
+    "@lottiefiles/dotlottie-web" "0.39.0"
+
+"@lottiefiles/dotlottie-web@0.39.0":
+  version "0.39.0"
+  resolved "https://registry.yarnpkg.com/@lottiefiles/dotlottie-web/-/dotlottie-web-0.39.0.tgz#bfbddcc6cb8becbd36424eebd5b294de4b66d6f5"
+  integrity sha512-kJWL6NEtbXQQHFK8kMfNte/5vuTHjFhL11a30s4PJSikao8IeEu+hLJH72flWHyTLpL4tmnxW3WkTKUwZ8Osug==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

#16 을 구현하였습니다.

## 2. 어떤 위험이나 장애를 발견했나요?

- X

## 3. 관련 스크린샷을 첨부해주세요.

### 카카오로그인 UI (lottie)
![image](https://github.com/user-attachments/assets/086e901f-dbba-4e95-a4b1-7a954747fabe)

### 초대장 앞면 작성 중
- 닉네임 유효성 검증
![image](https://github.com/user-attachments/assets/a2f3034f-fe21-401f-a61f-0f256eb57c6c)

- 텍스트 크기 & 컬러 별도 지정
![image](https://github.com/user-attachments/assets/7f5b6b75-6b38-4300-855b-1171a5c14184)

### 에러페이지
![image](https://github.com/user-attachments/assets/3789a059-fa64-4b24-be4e-adec78717160)


## 4. 완료 사항

- 로그인 화면 **애니메이션 `lottie`** 코드 추가
- 초대장 템플릿 데이터 중, **폰트크기와 컬러 데이터** 추가 (`text_attr`) 
- 에러페이지 구현 (존재하지 않는 페이지) << 추후 수정가능성 O 
- 초대장, 마이페이지 **디자인 수정사항 반영** 
   - 템플릿 선택 아이템 stroke 추가
   - 초대장 하단 box-shadow 추가  
   - 마이페이지 초대장 모아보기 > 아이콘 삭제
  

## 5. 추가 사항
