### PR TITLE
#25 feat: axios 에러 처리 로직 추가

### DIFF
--- a/src/api/errorCode.ts
+++ b/src/api/errorCode.ts
@@ -1,0 +1,21 @@
+export const errorCode = (code: string) => {
+  // 500 (서버 에러 발생 시, error-page에 적용될 객체)
+  const errorMap = {
+    INTERNAL_SERVER_ERROR: {
+      message: '서버 오류가 발생했습니다.',
+      btn_message: '새로고침',
+      action: () => window.location.reload(),
+    },
+    default: {
+      message: '예상치 못한 에러가 발생했습니다.',
+      btn_message: '다시시도',
+      action: () => window.location.reload(),
+    },
+  };
+
+  if (code in errorMap) {
+    return errorMap[code as keyof typeof errorMap];
+  }
+
+  return errorMap.default;
+};

--- a/src/api/fetchData.ts
+++ b/src/api/fetchData.ts
@@ -1,0 +1,52 @@
+import { privateAxios } from '../utils/customAxios';
+
+// [ ex. Page 내 API 호출 시 필수 코드 ]
+// const resetUserInfo = useResetRecoilState(UserInfo);
+// const { showBoundary } = useErrorBoundary();
+
+// const onClickButton = () => {
+//   fetchAPI(resetUserInfo, showBoundary).then((res) => {
+//     if (res.isSuccess) {
+//       alert(res.message);       // res.isSuccess == true 인 경우 로직 작성
+//     } else {
+//       console.log(res.message); // res.isSuccess == false인 경우 로직 작성
+//     }
+//   });
+// };
+
+// EXAMPLE API (참조용으로 추후 삭제할 것!!!)
+/**
+ *
+ * @param resetUserInfo    // 통신 중 토큰 만료 시, 저장된 userInfo 제거를 위함.
+ * @param showBoundary     // 서버 에러(500)를 catch하여 에러컴포넌트 ErrorFallback을 보여주기 위함.
+ * @returns
+ */
+export const fetchAPI = async (resetUserInfo: () => void, showBoundary: (error: any) => void) => {
+  const body = { code: '' };
+
+  const response = {
+    isSuccess: false,
+    message: '',
+    result: null,
+  };
+
+  try {
+    const result = await privateAxios(resetUserInfo).post('/invitation', body);
+    if (result.status === 200) {
+      response.isSuccess = true;
+      response.result = result.data.result;
+      response.message = result.data.message;
+    }
+  } catch (error: any) {
+    if (error.name !== 'GENERAL') {
+      // System Error (서버, 네트워크 에러)
+      showBoundary(error); // ErrorBoundary로 전달
+    } else {
+      // General Error (get, post)
+      console.log(error.message);
+    }
+    response.isSuccess = false;
+    response.message = error.message;
+  }
+  return response;
+};

--- a/src/pages/ErrorFallback.tsx
+++ b/src/pages/ErrorFallback.tsx
@@ -1,5 +1,14 @@
-const ErrorFallback = ({ error, resetErrorBoundary }: any) => {
-  return <div onClick={resetErrorBoundary}>{error}</div>;
+import DefaultError from '../components/error/DefaultError';
+import { errorCode } from '../api/errorCode';
+
+interface FallbackUIProps {
+  error: any; // 실제 에러 객체
+  resetErrorBoundary: () => void; // 에러 초기화 함수 (사용 X)
+}
+
+const ErrorFallback = ({ error }: FallbackUIProps) => {
+  const { message, btn_message, action } = errorCode(error.name);
+  return <DefaultError message={message} btnText={btn_message} onClick={action} />;
 };
 
 export default ErrorFallback;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

#25 를 구현하였습니다.

## 2. 어떤 위험이나 장애를 발견했나요?

- 추후 에러 코드가 추가되는 경우에 따라 코드 로직이 변화될 수 있습니다.
- API 연결이 많이 진행된 상황이 아니라 테스트된 케이스가 적습니다..ㅜㅜ

## 3. 관련 스크린샷을 첨부해주세요.

### 에러(500) 강제발생시켰을 때의 ErrorFallback UI
https://github.com/user-attachments/assets/16ced28e-5c7f-495a-8398-b5d41fa8b490



## 4. 완료 사항
에러 코드(상황)에 따라 유저에게 보여줄 **에러 처리 로직을 분리**하였습니다.

> - **토큰 에러 (401)** : toast message + login redirect
> - **서버 에러 (500)** : error-component page (에러 별도 페이지 = **`ErrorFallback`**)
> - **일반 에러 (40n)** : toast message

## 5. 추가 사항

error-boundary를 이용한 에러 처리는 처음이다보니 하드코딩이 된 느낌이 없지 않아 있는데.. 
코드 보면서 이해 안가시는 부분있으면 아는 선에서 최대한 답변 드리도록 하겠습니다 🥹
