### PR TITLE
#32 feat: qr 조회 api 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,10 +25,10 @@ function App() {
           <Routes>
             <Route path="/" element={<Login />} />
             <Route path="/login/*" element={<KakaoRedirectHandler />} />
+            <Route path="/invitation/:invitationId" element={<ReceiveInvitation />} />
             <Route element={<PrivateRoutes />}>
               <Route path="/home" element={<Home />} />
               <Route path="/invitation/create" element={<InvitationCreate />} />
-              <Route path="/invitation/:invitationId" element={<ReceiveInvitation />} />
               <Route path="/result/:invitationId" element={<Result />} />
               <Route path="/mypage" element={<MyPage />}>
                 <Route path="" element={<MyPageMain />} />

--- a/src/api/useGetQR.tsx
+++ b/src/api/useGetQR.tsx
@@ -6,7 +6,6 @@ import { UserInfo } from '../atom/UserInfo';
 
 export const useGetQR = (invitationId: string) => {
   const [data, setData] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
 
   const { showBoundary } = useErrorBoundary(); // 전역 에러 처리
   const resetUserInfo = useResetRecoilState(UserInfo); // 토큰 만료 시 유저 정보 초기화
@@ -21,7 +20,6 @@ export const useGetQR = (invitationId: string) => {
         });
 
         setData(response.data.result.qrUrl);
-        setError(null);
       } catch (error: any) {
         if (error.name !== 'GENERAL') {
           showBoundary(error); // 500 에러 → 전역 에러 핸들링
@@ -34,7 +32,7 @@ export const useGetQR = (invitationId: string) => {
     fetchData();
   }, [invitationId]);
 
-  return { data, error };
+  return { data };
 };
 
 export default useGetQR;

--- a/src/api/useGetQR.tsx
+++ b/src/api/useGetQR.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { privateAxios } from '../utils/customAxios';
+import { useErrorBoundary } from 'react-error-boundary';
+import { useResetRecoilState } from 'recoil';
+import { UserInfo } from '../atom/UserInfo';
+
+const BASE_URL = import.meta.env.VITE_SERVER_URL;
+
+export const useGetQR = (invitationId: string) => {
+  const [data, setData] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
+  const { showBoundary } = useErrorBoundary(); // 전역 에러 처리
+  const resetUserInfo = useResetRecoilState(UserInfo); // 토큰 만료 시 유저 정보 초기화
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await privateAxios(resetUserInfo).get(`${BASE_URL}/invitation/qr`, {
+          params: { invitationId },
+        });
+
+        if (response.status === 200) {
+          setData(response.data.result.qrUrl);
+          setError(null);
+        } else {
+          setError(response.data.message);
+        }
+      } catch (error: any) {
+        if (error.name !== 'GENERAL') {
+          showBoundary(error); // 500 에러 → 전역 에러 핸들링
+        } else {
+          console.log(error.message);
+        }
+      }
+    };
+
+    fetchData();
+  }, [invitationId]);
+
+  return { data, error };
+};
+
+export default useGetQR;

--- a/src/api/useGetQR.tsx
+++ b/src/api/useGetQR.tsx
@@ -4,27 +4,24 @@ import { useErrorBoundary } from 'react-error-boundary';
 import { useResetRecoilState } from 'recoil';
 import { UserInfo } from '../atom/UserInfo';
 
-const BASE_URL = import.meta.env.VITE_SERVER_URL;
-
 export const useGetQR = (invitationId: string) => {
-  const [data, setData] = useState<string>('');
+  const [data, setData] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
   const { showBoundary } = useErrorBoundary(); // 전역 에러 처리
   const resetUserInfo = useResetRecoilState(UserInfo); // 토큰 만료 시 유저 정보 초기화
 
   useEffect(() => {
+    if (!invitationId) return;
+
     const fetchData = async () => {
       try {
-        const response = await privateAxios(resetUserInfo).get(`${BASE_URL}/invitation/qr`, {
+        const response = await privateAxios(resetUserInfo).get(`/invitation/qr`, {
           params: { invitationId },
         });
 
-        if (response.status === 200) {
-          setData(response.data.result.qrUrl);
-          setError(null);
-        } else {
-          setError(response.data.message);
-        }
+        setData(response.data.result.qrUrl);
+        setError(null);
       } catch (error: any) {
         if (error.name !== 'GENERAL') {
           showBoundary(error); // 500 에러 → 전역 에러 핸들링

--- a/src/components/common/InvitationCard.tsx
+++ b/src/components/common/InvitationCard.tsx
@@ -5,6 +5,7 @@ import InvitationBack from '../result/InvitationBack';
 
 const InvitationCard = ({
   title,
+  imgURL,
   date,
   location,
   description,
@@ -12,6 +13,7 @@ const InvitationCard = ({
   fontColor = '#000',
 }: {
   title: string;
+  imgURL: string;
   date: string;
   location: string;
   description: string;
@@ -28,7 +30,7 @@ const InvitationCard = ({
       isTouched={isTouched}
     >
       <CardFront>
-        <InvitationFront />
+        <InvitationFront imgURL={imgURL} />
       </CardFront>
 
       <CardBack>

--- a/src/components/result/InvitationFront.tsx
+++ b/src/components/result/InvitationFront.tsx
@@ -6,9 +6,8 @@ const StyledImg = styled.img`
   border-radius: 0.5rem;
 `;
 
-const InvitationFront = () => {
-  //TODO: 경로를 동적으로 병경하도록 설정
-  return <StyledImg src="/image/Pre_Invi_Receipt.png" alt="front" />;
+const InvitationFront = ({ imgURL }: { imgURL: string }) => {
+  return <StyledImg src={imgURL} alt="front" />;
 };
 
 export default InvitationFront;

--- a/src/components/result/QRShareButton.tsx
+++ b/src/components/result/QRShareButton.tsx
@@ -12,7 +12,8 @@ const QRShareButton = () => {
 
   const { data: QRUrl } = useGetQR(invitationId);
 
-  const onClickDownload = useCallback((srcUrl: string, name: string) => {
+  const onClickDownload = useCallback((srcUrl: string | null, name: string) => {
+    if (!srcUrl) return;
     fetch(srcUrl, { method: 'GET' })
       .then((res) => res.blob())
       .then((blob) => {
@@ -38,12 +39,11 @@ const QRShareButton = () => {
     <Container>
       {isModalOpen && (
         <Modal width={10.37} hasCloseButton onClose={() => setIsModalOpen(false)}>
-          <QR src={QRUrl} alt="QR" />
+          <QR src={QRUrl ?? ''} alt="QR" />
           <DownloadButton
             size="small"
             color={theme.color.main}
             textColor="#fff"
-            // onClick={() => {}}
             onClick={() => onClickDownload(QRUrl, `${invitationId}_QR.png`)}
           >
             저장하기

--- a/src/components/result/QRShareButton.tsx
+++ b/src/components/result/QRShareButton.tsx
@@ -14,23 +14,13 @@ const QRShareButton = () => {
 
   const onClickDownload = useCallback((srcUrl: string | null, name: string) => {
     if (!srcUrl) return;
-    fetch(srcUrl, { method: 'GET' })
-      .then((res) => res.blob())
-      .then((blob) => {
-        const url = window.URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = name;
-        document.body.appendChild(a);
-        a.click();
-        setTimeout(() => {
-          window.URL.revokeObjectURL(url);
-        }, 1000);
-        a.remove();
-      })
-      .catch((err) => {
-        console.error('err', err);
-      });
+    const a = document.createElement('a');
+    a.href = srcUrl;
+    a.download = name;
+    a.target = '_blank';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
   }, []);
 
   console.log(QRUrl);

--- a/src/components/result/QRShareButton.tsx
+++ b/src/components/result/QRShareButton.tsx
@@ -4,16 +4,19 @@ import Modal from '../common/Modal';
 import Button from '../common/Button';
 import theme from '../../style/theme';
 import { useState } from 'react';
+import useGetQR from '../../api/useGetQR';
 
 const QRShareButton = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const invitationId = window.location.pathname.split('/')[2];
+
+  const { data: QRUrl } = useGetQR(invitationId);
 
   return (
     <Container>
       {isModalOpen && (
         <Modal width={10.37} hasCloseButton onClose={() => setIsModalOpen(false)}>
-          <QR>QR</QR>
-          <div>QR 이미지를 저장해 공유해보세요!</div>
+          <QR src={QRUrl} alt="QR" />
           <DownloadButton size="small" color={theme.color.main} textColor="#fff" onClick={() => {}}>
             저장하기
           </DownloadButton>
@@ -59,7 +62,7 @@ const DownloadButton = styled(Button)`
   height: 2rem;
 `;
 
-const QR = styled.div`
+const QR = styled.img`
   width: 8rem;
   height: 8rem;
   background-color: #ddd;

--- a/src/components/result/QRShareButton.tsx
+++ b/src/components/result/QRShareButton.tsx
@@ -3,7 +3,7 @@ import QRshare from '../../assets/QRsahre.svg';
 import Modal from '../common/Modal';
 import Button from '../common/Button';
 import theme from '../../style/theme';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import useGetQR from '../../api/useGetQR';
 
 const QRShareButton = () => {
@@ -12,12 +12,40 @@ const QRShareButton = () => {
 
   const { data: QRUrl } = useGetQR(invitationId);
 
+  const onClickDownload = useCallback((srcUrl: string, name: string) => {
+    fetch(srcUrl, { method: 'GET' })
+      .then((res) => res.blob())
+      .then((blob) => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = name;
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(() => {
+          window.URL.revokeObjectURL(url);
+        }, 1000);
+        a.remove();
+      })
+      .catch((err) => {
+        console.error('err', err);
+      });
+  }, []);
+
+  console.log(QRUrl);
+
   return (
     <Container>
       {isModalOpen && (
         <Modal width={10.37} hasCloseButton onClose={() => setIsModalOpen(false)}>
           <QR src={QRUrl} alt="QR" />
-          <DownloadButton size="small" color={theme.color.main} textColor="#fff" onClick={() => {}}>
+          <DownloadButton
+            size="small"
+            color={theme.color.main}
+            textColor="#fff"
+            // onClick={() => {}}
+            onClick={() => onClickDownload(QRUrl, `${invitationId}_QR.png`)}
+          >
             저장하기
           </DownloadButton>
         </Modal>

--- a/src/pages/ReceiveInvitation.tsx
+++ b/src/pages/ReceiveInvitation.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react';
 // 임시 데이터
 const data = {
   id: 0,
-  img: null,
+  imgURL: 'https://i.pinimg.com/736x/f9/d2/e5/f9d2e5eecb3109652fe71ca4cb0a2cd6.jpg',
   title: '연말파티 초대장',
   date: '2024.12.25',
   location: '강남역 어딘가',
@@ -73,6 +73,7 @@ const ReceiveInvitation = () => {
 
       <InvitationCard
         title={data.title}
+        imgURL={data.imgURL}
         date={data.date}
         location={data.location}
         description={data.description}

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -8,13 +8,12 @@ import { useEffect } from 'react';
 // 임시 데이터 (서버 응답)
 const data = {
   id: 0,
-  imgURL: 'https://i.pinimg.com/736x/f9/d2/e5/f9d2e5eecb3109652fe71ca4cb0a2cd6.jpg',
+  thumbnailUrl: 'https://i.pinimg.com/736x/f9/d2/e5/f9d2e5eecb3109652fe71ca4cb0a2cd6.jpg',
   templateKey: 'ALIEN',
   title: '연말파티 초대장',
-  date: '2024.12.25',
+  schedule: '2024.12.25',
   location: '강남역 어딘가',
-  description: '몸만 와라 친구들아',
-  made_date: '2024.12.14',
+  remark: '몸만 와라 친구들아',
 };
 
 const Result = () => {
@@ -27,16 +26,16 @@ const Result = () => {
       <MyPageHeader />
       <Title>초대장 생성 완료!</Title>
       <InvitationCard
-        //imgURL={data.imgURL}
+        imgURL={data.thumbnailUrl}
         title={data.title}
-        date={data.date}
+        date={data.schedule}
         location={data.location}
-        description={data.description}
+        description={data.remark}
         backgroundColor={template[data.templateKey].bg_color}
         fontColor={template[data.templateKey].bg_text_color}
       />
       <TouchMessage>초대장을 터치해주세요!</TouchMessage>
-      <ShareList imgURL={data.imgURL} />
+      <ShareList imgURL={data.thumbnailUrl} />
     </Container>
   );
 };

--- a/src/utils/customAxios.ts
+++ b/src/utils/customAxios.ts
@@ -41,7 +41,7 @@ const createPrivateAxios = (resetUserInfo: () => void) => {
   );
 
   instance.interceptors.response.use(
-    (response) => response.data,
+    (response) => response,
     async (error) => {
       if (error.response && error.response.data.status === 401) {
         showToast('로그인이 필요합니다. 로그인 페이지로 이동합니다.');


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
#32 를 구현했습니다
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
~~CORS 에러 때문에 다른 방법으로 수정 중에 있습니다..!~~
~~현재는 API hook 부분만 확인해주세요🙇🏻‍♀️~~

a태그를 이용하는 방식으로 수정하였습니다!
<br>

## 3. 관련 스크린샷을 첨부해주세요.
https://github.com/user-attachments/assets/147318f8-d49e-4af6-a173-e761bab2d0c3

https://github.com/user-attachments/assets/1f1f27d0-7846-4ed2-bc49-28a81c19d562


<br>

## 4. 완료 사항
- 초대장 조회(받기)가 `privateRoute` 안에 들어가있는 이슈가,,,,🚨 밖으로 꺼냈습니다,, 이제 로그인 없이도 접근 가능합니다,,

- InvitationFront 컴포넌트에 imgURL을 추가로 받도록 수정했습니다
props로 전달한 url이 앞면으로 나타납니다! 현재는 임시 이미지로 되어있습니다

- QR 조회 API 연결을 완료했습니다
현재 스웨거로 생성한 초대장이 하나 있는데, 해당 초대장으로 테스트 진행했습니다

- QR 다운로드의 경우 서버 수정이 추가로 필요할 것 같습니다!
현재는 그냥 이미지가 새 창에서 열리도록,, 구현되어있습니다
서버에서 특정 옵션을 설정할 경우 파일이 바로 다운로드 되는 것 같습니다 !

- API 연결 시 hook을 만들어 사용했습니다
이게 포인트,, 함수 호출에 useEffect까지 포함하여 하나의 api hook으로 구현했습니다!
```
const { data: QRUrl } = useGetQR(invitationId);
```
호출부에서는 이렇게 hook의 return값만 가져와서 바로 값을 이용할 수 있습니다!
불필요한 api 로직이 분리되기 때문에 코드 가독성을 해치지 않고 사용할 수 있습니다☺️

✅ 이게 privateAxios를 제대로 사용한 게 맞나,,, 해서 고민이었습니다,,, 이 부분 한번 확인부탁드려요 !

<br>

## 5. 추가 사항
